### PR TITLE
style(category): align hero typography and spacing with articles index

### DIFF
--- a/@pewriebontal/gatsby-theme-novela/src/sections/category/Category.Hero.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/sections/category/Category.Hero.tsx
@@ -6,6 +6,7 @@ import mediaqueries from '@styles/media';
 const CategoryHero = ({ category }) => {
   return (
     <Hero>
+      <Subheading>Articles in category</Subheading>
       <Heading>{category}</Heading>
     </Hero>
   );
@@ -20,21 +21,18 @@ const Hero = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin: 35px auto 110px;
-`;
+  margin: 100px auto 110px;
 
-const Heading = styled.h1`
-  font-size: 38px;
-  font-family: ${p => p.theme.fonts.sansSerif};
-  color: ${p => p.theme.colors.primary};
-  margin-bottom: 15px;
-  font-weight: 600;
-  text-transform: capitalize;
+  ${mediaqueries.desktop`
+    margin: 100px auto 70px;
+  `}
 
   ${mediaqueries.tablet`
+    margin: 100px auto 70px;
   `}
 
   ${mediaqueries.phablet`
+    margin: 80px auto 80px;
   `}
 `;
 
@@ -42,12 +40,36 @@ const Subheading = styled.p`
   margin: 0 auto;
   max-width: 450px;
   color: ${p => p.theme.colors.grey};
-  font-size: 18px;
+  font-size: 16px;
   font-family: ${p => p.theme.fonts.sansSerif};
   line-height: 1.4;
   text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  margin-bottom: 15px;
 
   ${mediaqueries.phablet`
     font-size: 14px;
+    margin-bottom: 10px;
+  `}
+`;
+
+const Heading = styled.h1`
+  font-style: normal;
+  font-weight: 600;
+  font-size: 52px;
+  line-height: 1.15;
+  font-family: ${p => p.theme.fonts.sansSerif};
+  color: ${p => p.theme.colors.primary};
+  text-transform: capitalize;
+  text-align: center;
+
+  ${mediaqueries.desktop`
+    font-size: 38px;
+  `}
+
+  ${mediaqueries.phablet`
+    font-size: 32px;
   `}
 `;


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [x] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

This PR polishes the UI for category listing pages (`/category/[name]`) to ensure visual consistency with the rest of the Novela theme. It specifically targets the `CategoryHero` component to align its typography and spacing with the main Articles index.

**Key Changes:**

- **Added "Subheading" eyebrow label:** Re-introduced the "ARTICLES IN CATEGORY" label with proper uppercase styling and letter spacing to provide clear context for the view.
- **Responsive Typography:** Updated the main heading to use fluid font sizes (scaling from 52px on desktop to 32px on mobile), matching the behavior of `Articles.Hero`.
- **Vertical Rhythm Alignment:** Adjusted the hero container margins to match the spacing standards used on Author and Article listing pages.
- **CSS Cleanup:** Replaced fixed font sizes with theme-consistent responsive styles.