### PR TITLE
@feature/search

### DIFF
--- a/@pewriebontal/gatsby-theme-novela/package.json
+++ b/@pewriebontal/gatsby-theme-novela/package.json
@@ -47,6 +47,7 @@
     "@mdx-js/react": "^1.0.27",
     "@raae/gatsby-remark-oembed": "^0.1.1",
     "contentful-cli": "^1.16.0",
+    "fuse.js": "^6.6.2",
     "gatsby": "^3.15.0",
     "gatsby-image": "^2.2.7",
     "gatsby-paginate": "^1.1.0",

--- a/@pewriebontal/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -1,18 +1,18 @@
-import React, { useState, useEffect } from "react";
-import styled from "@emotion/styled";
-import { Link, navigate, graphql, useStaticQuery } from "gatsby";
-import { useColorMode } from "theme-ui";
+import React, { useState, useEffect } from 'react';
+import styled from '@emotion/styled';
+import { Link, navigate, graphql, useStaticQuery } from 'gatsby';
+import { useColorMode } from 'theme-ui';
 
-import Section from "@components/Section";
-import Logo from "@components/Logo";
+import Section from '@components/Section';
+import Logo from '@components/Logo';
 
-import Icons from "@icons";
-import mediaqueries from "@styles/media";
+import Icons from '@icons';
+import mediaqueries from '@styles/media';
 import {
   copyToClipboard,
   getWindowDimensions,
   getBreakpointFromTheme,
-} from "@utils";
+} from '@utils';
 
 const siteQuery = graphql`
   {
@@ -20,10 +20,25 @@ const siteQuery = graphql`
       pluginOptions {
         rootPath
         basePath
+        search
+        searchPath
       }
     }
   }
 `;
+
+function normalizePath(pathname: string) {
+  return `/${pathname || ''}`.replace(/\/\/+/g, '/').replace(/\/$/, '') || '/';
+}
+
+function buildSearchPath(searchPath: string, basePath: string) {
+  if (searchPath) return normalizePath(searchPath);
+
+  const normalizedBasePath = normalizePath(basePath || '/');
+  return normalizedBasePath === '/'
+    ? '/search'
+    : normalizePath(`${normalizedBasePath}/search`);
+}
 
 const DarkModeToggle: React.FC<{}> = () => {
   const [colorMode, setColorMode] = useColorMode();
@@ -39,8 +54,8 @@ const DarkModeToggle: React.FC<{}> = () => {
       isDark={isDark}
       onClick={toggleColorMode}
       data-a11y="false"
-      aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
-      title={isDark ? "Activate light mode" : "Activate dark mode"}
+      aria-label={isDark ? 'Activate light mode' : 'Activate dark mode'}
+      title={isDark ? 'Activate light mode' : 'Activate dark mode'}
     >
       <MoonOrSun isDark={isDark} />
       <MoonMask isDark={isDark} />
@@ -52,7 +67,7 @@ const SharePageButton: React.FC<{}> = () => {
   const [hasCopied, setHasCopied] = useState<boolean>(false);
   const [colorMode] = useColorMode();
   const isDark = colorMode === `dark`;
-  const fill = isDark ? "#fff" : "#000";
+  const fill = isDark ? '#fff' : '#000';
 
   function copyToClipboardOnClick() {
     if (hasCopied) return;
@@ -81,30 +96,74 @@ const SharePageButton: React.FC<{}> = () => {
   );
 };
 
+const SearchPageLink: React.FC<{ to: string }> = ({ to }) => {
+  const [colorMode] = useColorMode();
+  const isDark = colorMode === 'dark';
+  const fill = isDark ? '#fff' : '#000';
+
+  return (
+    <IconLink
+      to={to}
+      data-a11y="false"
+      aria-label="Search articles"
+      title="Search articles"
+    >
+      <Icons.Search fill={fill} />
+    </IconLink>
+  );
+};
+
 const NavigationHeader: React.FC<{}> = () => {
   const [showBackArrow, setShowBackArrow] = useState<boolean>(false);
-  const [previousPath, setPreviousPath] = useState<string>("/");
+  const [previousPath, setPreviousPath] = useState<string>('/');
   const { sitePlugin } = useStaticQuery(siteQuery);
 
   const [colorMode] = useColorMode();
-  const fill = colorMode === "dark" ? "#fff" : "#000";
-  const { rootPath, basePath } = sitePlugin.pluginOptions;
+  const fill = colorMode === 'dark' ? '#fff' : '#000';
+  const { rootPath, basePath, search, searchPath } = sitePlugin.pluginOptions;
+  const resolvedSearchPath = buildSearchPath(searchPath, rootPath || basePath);
 
   useEffect(() => {
     const { width } = getWindowDimensions();
-    const phablet = getBreakpointFromTheme("phablet");
+    const phablet = getBreakpointFromTheme('phablet');
 
-    const prev = localStorage.getItem("previousPath");
+    const prev = localStorage.getItem('previousPath');
     const previousPathWasHomepage =
-      prev === (rootPath || basePath) || (prev && prev.includes("/page/"));
+      prev === (rootPath || basePath) || (prev && prev.includes('/page/'));
     const currentPathIsHomepage =
-      location.pathname === (rootPath || basePath) || location.pathname.includes("/page/");
+      location.pathname === (rootPath || basePath) ||
+      location.pathname.includes('/page/');
 
     setShowBackArrow(
       previousPathWasHomepage && !currentPathIsHomepage && width <= phablet,
     );
     setPreviousPath(prev);
   }, []);
+
+  useEffect(() => {
+    if (search === false) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isSearchPage = window.location.pathname === resolvedSearchPath;
+
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        event.preventDefault();
+        if (isSearchPage) {
+          navigate(previousPath || '/');
+        } else {
+          navigate(resolvedSearchPath);
+        }
+      }
+
+      if (event.key === 'Escape' && isSearchPage) {
+        event.preventDefault();
+        navigate(previousPath || '/');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [search, resolvedSearchPath, previousPath]);
 
   return (
     <Section>
@@ -114,7 +173,7 @@ const NavigationHeader: React.FC<{}> = () => {
           data-a11y="false"
           title="Navigate back to the homepage"
           aria-label="Navigate back to the homepage"
-          back={showBackArrow ? "true" : "false"}
+          back={showBackArrow ? 'true' : 'false'}
         >
           {showBackArrow && (
             <BackArrowIconContainer>
@@ -135,6 +194,7 @@ const NavigationHeader: React.FC<{}> = () => {
             </button>
           ) : (
             <>
+              {search !== false && <SearchPageLink to={resolvedSearchPath} />}
               <SharePageButton />
               <DarkModeToggle />
             </>
@@ -184,20 +244,20 @@ const LogoLink = styled(Link)<{ back: string }>`
   position: relative;
   display: flex;
   align-items: center;
-  left: ${p => (p.back === "true" ? "-54px" : 0)};
+  left: ${(p) => (p.back === 'true' ? '-54px' : 0)};
 
   ${mediaqueries.desktop_medium`
     left: 0
   `}
 
   &[data-a11y="true"]:focus::after {
-    content: "";
+    content: '';
     position: absolute;
     left: -10%;
     top: -30%;
     width: 120%;
     height: 160%;
-    border: 2px solid ${p => p.theme.colors.accent};
+    border: 2px solid ${(p) => p.theme.colors.accent};
     background: rgba(255, 255, 255, 0.01);
     border-radius: 5px;
   }
@@ -222,17 +282,17 @@ const NavControls = styled.div`
 const ToolTip = styled.div<{ isDark: boolean; hasCopied: boolean }>`
   position: absolute;
   padding: 4px 13px;
-  background: ${p => (p.isDark ? "#000" : "rgba(0,0,0,0.1)")};
-  color: ${p => (p.isDark ? "#fff" : "#000")};
+  background: ${(p) => (p.isDark ? '#000' : 'rgba(0,0,0,0.1)')};
+  color: ${(p) => (p.isDark ? '#fff' : '#000')};
   border-radius: 5px;
   font-size: 14px;
   top: -35px;
-  opacity: ${p => (p.hasCopied ? 1 : 0)};
-  transform: ${p => (p.hasCopied ? "translateY(-3px)" : "none")};
+  opacity: ${(p) => (p.hasCopied ? 1 : 0)};
+  transform: ${(p) => (p.hasCopied ? 'translateY(-3px)' : 'none')};
   transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
 
   &::after {
-    content: "";
+    content: '';
     position: absolute;
     left: 0;
     right: 0;
@@ -242,7 +302,7 @@ const ToolTip = styled.div<{ isDark: boolean; hasCopied: boolean }>`
     height: 0;
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;
-    border-top: 6px solid ${p => (p.isDark ? "#000" : "rgba(0,0,0,0.1)")};
+    border-top: 6px solid ${(p) => (p.isDark ? '#000' : 'rgba(0,0,0,0.1)')};
   }
 `;
 
@@ -262,14 +322,54 @@ const IconWrapper = styled.button<{ isDark: boolean }>`
     opacity: 1;
   }
 
-  &[data-a11y="true"]:focus::after {
-    content: "";
+  &[data-a11y='true']:focus::after {
+    content: '';
     position: absolute;
     left: 0;
     top: -30%;
     width: 100%;
     height: 160%;
-    border: 2px solid ${p => p.theme.colors.accent};
+    border: 2px solid ${(p) => p.theme.colors.accent};
+    background: rgba(255, 255, 255, 0.01);
+    border-radius: 5px;
+  }
+
+  ${mediaqueries.tablet`
+    display: inline-flex;
+    transform: scale(0.708);
+    margin-left: 10px;
+
+
+    &:hover {
+      opacity: 0.5;
+    }
+  `}
+`;
+
+const IconLink = styled(Link)`
+  opacity: 0.5;
+  position: relative;
+  border-radius: 5px;
+  width: 40px;
+  height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.3s ease;
+  margin-left: 30px;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &[data-a11y='true']:focus::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: -30%;
+    width: 100%;
+    height: 160%;
+    border: 2px solid ${(p) => p.theme.colors.accent};
     background: rgba(255, 255, 255, 0.01);
     border-radius: 5px;
   }
@@ -292,29 +392,29 @@ const MoonOrSun = styled.div<{ isDark: boolean }>`
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  border: ${p => (p.isDark ? "4px" : "2px")} solid
-    ${p => p.theme.colors.primary};
-  background: ${p => p.theme.colors.primary};
-  transform: scale(${p => (p.isDark ? 0.55 : 1)});
+  border: ${(p) => (p.isDark ? '4px' : '2px')} solid
+    ${(p) => p.theme.colors.primary};
+  background: ${(p) => p.theme.colors.primary};
+  transform: scale(${(p) => (p.isDark ? 0.55 : 1)});
   transition: all 0.45s ease;
-  overflow: ${p => (p.isDark ? "visible" : "hidden")};
+  overflow: ${(p) => (p.isDark ? 'visible' : 'hidden')};
 
   &::before {
-    content: "";
+    content: '';
     position: absolute;
     right: -9px;
     top: -9px;
     height: 24px;
     width: 24px;
-    border: 2px solid ${p => p.theme.colors.primary};
+    border: 2px solid ${(p) => p.theme.colors.primary};
     border-radius: 50%;
-    transform: translate(${p => (p.isDark ? "14px, -14px" : "0, 0")});
-    opacity: ${p => (p.isDark ? 0 : 1)};
+    transform: translate(${(p) => (p.isDark ? '14px, -14px' : '0, 0')});
+    opacity: ${(p) => (p.isDark ? 0 : 1)};
     transition: transform 0.45s ease;
   }
 
   &::after {
-    content: "";
+    content: '';
     width: 8px;
     height: 8px;
     border-radius: 50%;
@@ -322,18 +422,18 @@ const MoonOrSun = styled.div<{ isDark: boolean }>`
     position: absolute;
     top: 50%;
     left: 50%;
-    box-shadow: 0 -23px 0 ${p => p.theme.colors.primary},
-      0 23px 0 ${p => p.theme.colors.primary},
-      23px 0 0 ${p => p.theme.colors.primary},
-      -23px 0 0 ${p => p.theme.colors.primary},
-      15px 15px 0 ${p => p.theme.colors.primary},
-      -15px 15px 0 ${p => p.theme.colors.primary},
-      15px -15px 0 ${p => p.theme.colors.primary},
-      -15px -15px 0 ${p => p.theme.colors.primary};
-    transform: scale(${p => (p.isDark ? 1 : 0)});
+    box-shadow: 0 -23px 0 ${(p) => p.theme.colors.primary},
+      0 23px 0 ${(p) => p.theme.colors.primary},
+      23px 0 0 ${(p) => p.theme.colors.primary},
+      -23px 0 0 ${(p) => p.theme.colors.primary},
+      15px 15px 0 ${(p) => p.theme.colors.primary},
+      -15px 15px 0 ${(p) => p.theme.colors.primary},
+      15px -15px 0 ${(p) => p.theme.colors.primary},
+      -15px -15px 0 ${(p) => p.theme.colors.primary};
+    transform: scale(${(p) => (p.isDark ? 1 : 0)});
     transition: all 0.35s ease;
 
-    ${p => mediaqueries.tablet`
+    ${(p) => mediaqueries.tablet`
       transform: scale(${p.isDark ? 0.92 : 0});
     `}
   }
@@ -347,10 +447,10 @@ const MoonMask = styled.div<{ isDark: boolean }>`
   width: 24px;
   border-radius: 50%;
   border: 0;
-  background: ${p => p.theme.colors.background};
-  transform: translate(${p => (p.isDark ? "14px, -14px" : "0, 0")});
-  opacity: ${p => (p.isDark ? 0 : 1)};
-  transition: ${p => p.theme.colorModeTransition}, transform 0.45s ease;
+  background: ${(p) => p.theme.colors.background};
+  transform: translate(${(p) => (p.isDark ? '14px, -14px' : '0, 0')});
+  opacity: ${(p) => (p.isDark ? 0 : 1)};
+  transition: ${(p) => p.theme.colorModeTransition}, transform 0.45s ease;
 `;
 
 const Hidden = styled.span`

--- a/@pewriebontal/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -13,6 +13,7 @@ import {
   getWindowDimensions,
   getBreakpointFromTheme,
 } from '@utils';
+import { buildSearchPath } from '../../gatsby/utils/search';
 
 const siteQuery = graphql`
   {
@@ -27,17 +28,12 @@ const siteQuery = graphql`
   }
 `;
 
-function normalizePath(pathname: string) {
-  return `/${pathname || ''}`.replace(/\/\/+/g, '/').replace(/\/$/, '') || '/';
-}
-
-function buildSearchPath(searchPath: string, basePath: string) {
-  if (searchPath) return normalizePath(searchPath);
-
-  const normalizedBasePath = normalizePath(basePath || '/');
-  return normalizedBasePath === '/'
-    ? '/search'
-    : normalizePath(`${normalizedBasePath}/search`);
+function isTextEntryElement(element: Element | null) {
+  return (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    (element instanceof HTMLElement && element.isContentEditable)
+  );
 }
 
 const DarkModeToggle: React.FC<{}> = () => {
@@ -121,7 +117,7 @@ const NavigationHeader: React.FC<{}> = () => {
   const [colorMode] = useColorMode();
   const fill = colorMode === 'dark' ? '#fff' : '#000';
   const { rootPath, basePath, search, searchPath } = sitePlugin.pluginOptions;
-  const resolvedSearchPath = buildSearchPath(searchPath, rootPath || basePath);
+  const resolvedSearchPath = buildSearchPath(searchPath, basePath);
 
   useEffect(() => {
     const { width } = getWindowDimensions();
@@ -145,8 +141,16 @@ const NavigationHeader: React.FC<{}> = () => {
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const isSearchPage = window.location.pathname === resolvedSearchPath;
+      const activeElement = document.activeElement;
+      const isSearchInput =
+        activeElement instanceof HTMLInputElement &&
+        activeElement.dataset.searchInput === 'true';
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        if (isTextEntryElement(activeElement) && !isSearchInput) {
+          return;
+        }
+
         event.preventDefault();
         if (isSearchPage) {
           navigate(previousPath || '/');
@@ -155,8 +159,7 @@ const NavigationHeader: React.FC<{}> = () => {
         }
       }
 
-      if (event.key === 'Escape' && isSearchPage) {
-        event.preventDefault();
+      if (event.key === 'Escape' && isSearchPage && isSearchInput) {
         navigate(previousPath || '/');
       }
     };

--- a/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
+++ b/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
@@ -47,20 +47,7 @@ function getUniqueListBy(array, key) {
 
 const byDate = (a, b) => new Date(b.dateForSEO) - new Date(a.dateForSEO);
 
-function normalizePath(pathname) {
-  return (
-    `/${pathname || ''}`.replaceAll(/\/\/+/g, '/').replace(/\/$/, '') || '/'
-  );
-}
-
-function buildSearchPath(searchPath, basePath) {
-  if (searchPath) return normalizePath(searchPath);
-
-  const normalizedBasePath = normalizePath(basePath || '/');
-  return normalizedBasePath === '/'
-    ? '/search'
-    : normalizePath(`${normalizedBasePath}/search`);
-}
+const { buildSearchPath } = require('../utils/search');
 
 function normalizeSearchText(value = '') {
   return String(value || '')
@@ -79,22 +66,25 @@ function buildSearchIndex(articles) {
     id: article.id,
     title: article.title,
     slug: article.slug,
+    hero: {
+      regular: article.hero && article.hero.regular,
+      narrow: article.hero && article.hero.narrow,
+    },
     excerpt: normalizeSearchText(article.excerpt),
     author: article.author || '',
     categories: article.categories || [],
     date: article.date,
     timeToRead: article.timeToRead,
-    hero: {
-      regular: article.hero && article.hero.regular,
-      narrow: article.hero && article.hero.narrow,
-    },
     body: normalizeSearchText(article.body).slice(0, 8000),
   }));
 }
 
 // ///////////////////////////////////////////////////////
 
-module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
+module.exports = async (
+  { actions: { createPage }, graphql, store },
+  themeOptions,
+) => {
   const {
     rootPath,
     basePath = '/',
@@ -244,7 +234,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
   if (search) {
     log('Creating', 'search page');
     const searchIndex = buildSearchIndex(articlesThatArentSecret);
-    const publicPath = path.join(process.cwd(), 'public');
+    const publicPath = path.join(store.getState().program.directory, 'public');
     if (!fs.existsSync(publicPath)) {
       fs.mkdirSync(publicPath, { recursive: true });
     }

--- a/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
+++ b/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
@@ -6,6 +6,7 @@ const log = (message, section) =>
   console.log(`\n\u001B[36m${message} \u001B[4m${section}\u001B[0m\u001B[0m\n`);
 
 const path = require('node:path');
+const fs = require('node:fs');
 const createPaginatedPages = require('gatsby-paginate');
 
 const templatesDirectory = path.resolve(__dirname, '../../templates');
@@ -242,13 +243,22 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
 
   if (search) {
     log('Creating', 'search page');
+    const searchIndex = buildSearchIndex(articlesThatArentSecret);
+    const publicPath = path.join(process.cwd(), 'public');
+    if (!fs.existsSync(publicPath)) {
+      fs.mkdirSync(publicPath, { recursive: true });
+    }
+    fs.writeFileSync(
+      path.join(publicPath, 'search-index.json'),
+      JSON.stringify(searchIndex),
+    );
+
     createPage({
       path: resolvedSearchPath,
       component: templates.search,
       context: {
         basePath,
         searchPath: resolvedSearchPath,
-        searchIndex: buildSearchIndex(articlesThatArentSecret),
       },
     });
   }

--- a/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
+++ b/@pewriebontal/gatsby-theme-novela/src/gatsby/node/createPages.js
@@ -14,6 +14,7 @@ const templates = {
   article: path.resolve(templatesDirectory, 'article.template.tsx'),
   author: path.resolve(templatesDirectory, 'author.template.tsx'),
   category: path.resolve(templatesDirectory, 'category.template.tsx'),
+  search: path.resolve(templatesDirectory, 'search.template.tsx'),
 };
 
 const query = require('../data/data.query');
@@ -45,6 +46,51 @@ function getUniqueListBy(array, key) {
 
 const byDate = (a, b) => new Date(b.dateForSEO) - new Date(a.dateForSEO);
 
+function normalizePath(pathname) {
+  return (
+    `/${pathname || ''}`.replaceAll(/\/\/+/g, '/').replace(/\/$/, '') || '/'
+  );
+}
+
+function buildSearchPath(searchPath, basePath) {
+  if (searchPath) return normalizePath(searchPath);
+
+  const normalizedBasePath = normalizePath(basePath || '/');
+  return normalizedBasePath === '/'
+    ? '/search'
+    : normalizePath(`${normalizedBasePath}/search`);
+}
+
+function normalizeSearchText(value = '') {
+  return String(value || '')
+    .replaceAll(/```[\s\S]*?```/g, ' ')
+    .replaceAll(/`([^`]+)`/g, '$1')
+    .replaceAll(/!\[[^\]]*]\([^)]+\)/g, ' ')
+    .replaceAll(/\[([^\]]+)]\([^)]+\)/g, '$1')
+    .replaceAll(/<[^>]+>/g, ' ')
+    .replaceAll(/[>#*_~|]/g, ' ')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+}
+
+function buildSearchIndex(articles) {
+  return articles.map((article) => ({
+    id: article.id,
+    title: article.title,
+    slug: article.slug,
+    excerpt: normalizeSearchText(article.excerpt),
+    author: article.author || '',
+    categories: article.categories || [],
+    date: article.date,
+    timeToRead: article.timeToRead,
+    hero: {
+      regular: article.hero && article.hero.regular,
+      narrow: article.hero && article.hero.narrow,
+    },
+    body: normalizeSearchText(article.body).slice(0, 8000),
+  }));
+}
+
 // ///////////////////////////////////////////////////////
 
 module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
@@ -57,6 +103,8 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
     pageLength = 6,
     sources = {},
     mailchimp = '',
+    search = true,
+    searchPath,
   } = themeOptions;
 
   const { data } = await graphql(`
@@ -136,6 +184,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
   ].sort(byDate);
 
   const articlesThatArentSecret = articles.filter((article) => !article.secret);
+  const resolvedSearchPath = buildSearchPath(searchPath, basePath);
 
   // Combining together all the authors from different sources
   authors = getUniqueListBy(
@@ -190,6 +239,19 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
       limit: pageLength,
     },
   });
+
+  if (search) {
+    log('Creating', 'search page');
+    createPage({
+      path: resolvedSearchPath,
+      component: templates.search,
+      context: {
+        basePath,
+        searchPath: resolvedSearchPath,
+        searchIndex: buildSearchIndex(articlesThatArentSecret),
+      },
+    });
+  }
 
   /**
    * Once the list of articles have bene created, we need to make individual article posts.

--- a/@pewriebontal/gatsby-theme-novela/src/gatsby/utils/search.js
+++ b/@pewriebontal/gatsby-theme-novela/src/gatsby/utils/search.js
@@ -1,0 +1,17 @@
+function normalizePath(pathname) {
+  return `/${pathname || ''}`.replace(/\/\/+/g, '/').replace(/\/$/, '') || '/';
+}
+
+function buildSearchPath(searchPath, basePath) {
+  if (searchPath) return normalizePath(searchPath);
+
+  const normalizedBasePath = normalizePath(basePath || '/');
+  return normalizedBasePath === '/'
+    ? '/search'
+    : normalizePath(`${normalizedBasePath}/search`);
+}
+
+module.exports = {
+  normalizePath,
+  buildSearchPath,
+};

--- a/@pewriebontal/gatsby-theme-novela/src/icons/index.ts
+++ b/@pewriebontal/gatsby-theme-novela/src/icons/index.ts
@@ -26,6 +26,7 @@ import Copied from './ui/Copied.Icon';
 import Copy from './ui/Copy.Icon';
 import Ex from './ui/Ex.Icon';
 import Link from './ui/Link.Icon';
+import Search from './ui/Search.Icon';
 import ToggleOpen from './ui/ToggleOpen.Icon';
 import ToggleClose from './ui/ToggleClose.Icon';
 import Rows from './ui/Rows.Icon';
@@ -58,6 +59,7 @@ export default {
   Copy,
   Ex,
   Link,
+  Search,
   ToggleClose,
   ToggleOpen,
   Rows,

--- a/@pewriebontal/gatsby-theme-novela/src/icons/ui/Search.Icon.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/icons/ui/Search.Icon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { Icon } from '@types';
+
+const SearchIcon: Icon = ({ fill = '#08080B' }) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10.75 18.5C15.0302 18.5 18.5 15.0302 18.5 10.75C18.5 6.46979 15.0302 3 10.75 3C6.46979 3 3 6.46979 3 10.75C3 15.0302 6.46979 18.5 10.75 18.5Z"
+      stroke={fill}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.25 16.25L21 21"
+      stroke={fill}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SearchIcon;

--- a/@pewriebontal/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
@@ -42,9 +42,11 @@ const ArticlesList: React.FC<ArticlesListProps> = ({
   if (!articles) return null;
 
   const hasOnlyOneArticle = articles.length === 1;
-  const { gridLayout = 'tiles', hasSetGridLayout, getGridLayout } = useContext(
-    GridLayoutContext,
-  );
+  const {
+    gridLayout = 'tiles',
+    hasSetGridLayout,
+    getGridLayout,
+  } = useContext(GridLayoutContext);
 
   /**
    * We're taking the flat array of articles [{}, {}, {}...]
@@ -92,7 +94,11 @@ const ListItem: React.FC<ArticlesListItemProps> = ({ article, narrow }) => {
 
   const { gridLayout } = useContext(GridLayoutContext);
   const hasOverflow = narrow && article.title.length > 35;
-  const imageSource = narrow ? article.hero.narrow : article.hero.regular;
+  const imageSource = article.hero
+    ? narrow
+      ? article.hero.narrow
+      : article.hero.regular
+    : null;
   const hasHeroImage =
     imageSource &&
     Object.keys(imageSource).length !== 0 &&
@@ -160,10 +166,10 @@ const showDetails = css`
 
 const ArticlesListContainer = styled.div<{ alwaysShowAllDetails?: boolean }>`
   transition: opacity 0.25s;
-  ${p => p.alwaysShowAllDetails && showDetails}
+  ${(p) => p.alwaysShowAllDetails && showDetails}
 `;
 
-const listTile = p => css`
+const listTile = (p) => css`
   position: relative;
   display: grid;
   grid-template-columns: ${p.reverse
@@ -189,7 +195,7 @@ const listTile = p => css`
   `}
 `;
 
-const listItemRow = p => css`
+const listItemRow = (p) => css`
   display: grid;
   grid-template-rows: 1fr;
   grid-template-columns: 1fr 488px;
@@ -219,7 +225,7 @@ const listItemRow = p => css`
   `}
 `;
 
-const listItemTile = p => css`
+const listItemTile = (p) => css`
   position: relative;
 
   ${mediaqueries.tablet`
@@ -239,7 +245,7 @@ const listItemTile = p => css`
 `;
 
 // If only 1 article, dont create 2 rows.
-const listRow = p => css`
+const listRow = (p) => css`
   display: grid;
   grid-template-rows: ${p.hasOnlyOneArticle ? '1fr' : '1fr 1fr'};
 `;
@@ -249,19 +255,19 @@ const List = styled.div<{
   gridLayout: string;
   hasOnlyOneArticle: boolean;
 }>`
-  ${p => (p.gridLayout === 'tiles' ? listTile : listRow)}
+  ${(p) => (p.gridLayout === 'tiles' ? listTile : listRow)}
 `;
 
 const Item = styled.div<{ gridLayout: string }>`
-  ${p => (p.gridLayout === 'rows' ? listItemRow : listItemTile)}
+  ${(p) => (p.gridLayout === 'rows' ? listItemRow : listItemTile)}
 `;
 
 const ImageContainer = styled.div<{ narrow: boolean; gridLayout: string }>`
   position: relative;
-  height: ${p => (p.gridLayout === 'tiles' ? '280px' : '220px')};
-  box-shadow: 0 30px 60px -10px rgba(0, 0, 0, ${p => (p.narrow ? 0.22 : 0.3)}),
-    0 18px 36px -18px rgba(0, 0, 0, ${p => (p.narrow ? 0.25 : 0.33)});
-  margin-bottom: ${p => (p.gridLayout === 'tiles' ? '30px' : 0)};
+  height: ${(p) => (p.gridLayout === 'tiles' ? '280px' : '220px')};
+  box-shadow: 0 30px 60px -10px rgba(0, 0, 0, ${(p) => (p.narrow ? 0.22 : 0.3)}),
+    0 18px 36px -18px rgba(0, 0, 0, ${(p) => (p.narrow ? 0.25 : 0.33)});
+  margin-bottom: ${(p) => (p.gridLayout === 'tiles' ? '30px' : 0)};
   transition: transform 0.3s var(--ease-out-quad),
     box-shadow 0.3s var(--ease-out-quad);
 
@@ -285,8 +291,8 @@ const ImageContainer = styled.div<{ narrow: boolean; gridLayout: string }>`
 
 const Title = styled(Headings.h2)`
   font-size: 21px;
-  font-family: ${p => p.theme.fonts.serif};
-  margin-bottom: ${p =>
+  font-family: ${(p) => p.theme.fonts.serif};
+  margin-bottom: ${(p) =>
     p.hasOverflow && p.gridLayout === 'tiles' ? '35px' : '10px'};
   transition: color 0.3s ease-in-out;
   ${limitToTwoLines};
@@ -315,9 +321,10 @@ const Excerpt = styled.p<{
   ${limitToTwoLines};
   font-size: 16px;
   margin-bottom: 10px;
-  color: ${p => p.theme.colors.grey};
-  display: ${p => (p.hasOverflow && p.gridLayout === 'tiles' ? 'none' : 'box')};
-  max-width: ${p => (p.narrow ? '415px' : '515px')};
+  color: ${(p) => p.theme.colors.grey};
+  display: ${(p) =>
+    p.hasOverflow && p.gridLayout === 'tiles' ? 'none' : 'box'};
+  max-width: ${(p) => (p.narrow ? '415px' : '515px')};
 
   ${mediaqueries.desktop`
     display: -webkit-box;
@@ -338,7 +345,7 @@ const Excerpt = styled.p<{
 const MetaData = styled.div`
   font-weight: 600;
   font-size: 16px;
-  color: ${p => p.theme.colors.grey};
+  color: ${(p) => p.theme.colors.grey};
   opacity: 0.33;
 
   ${mediaqueries.phablet`
@@ -367,7 +374,7 @@ const ArticleLink = styled(Link)`
 
   &:hover h2,
   &:focus h2 {
-    color: ${p => p.theme.colors.accent};
+    color: ${(p) => p.theme.colors.accent};
   }
 
   &[data-a11y='true']:focus::after {
@@ -377,7 +384,7 @@ const ArticleLink = styled(Link)`
     top: -2%;
     width: 103%;
     height: 104%;
-    border: 3px solid ${p => p.theme.colors.accent};
+    border: 3px solid ${(p) => p.theme.colors.accent};
     background: rgba(255, 255, 255, 0.01);
     border-radius: 5px;
   }
@@ -402,7 +409,7 @@ const CategoryLine = styled.div`
 `;
 
 const CategoryName = styled.span`
-  color: ${p => p.theme.colors.grey};
+  color: ${(p) => p.theme.colors.grey};
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.1em;

--- a/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import Fuse from 'fuse.js';
 
@@ -10,26 +10,26 @@ import Icons from '@icons';
 import mediaqueries from '@styles/media';
 import ArticlesList from '../sections/articles/Articles.List';
 
+import { IArticle } from '@types';
+
 interface SearchItem {
   author: string;
   body: string;
   categories: string[];
   date: string;
-  excerpt: string;
-  hero?: {
-    narrow?: Record<string, unknown>;
-    regular?: Record<string, unknown>;
-  };
+  excerpt: string | React.ReactNode;
+  hero?: IArticle['hero'];
   id: string;
   slug: string;
   timeToRead?: number;
-  title: string;
+  title: string | React.ReactNode;
 }
 
 interface SearchTemplateProps {
   location: Location;
   pageContext: {
-    searchIndex: SearchItem[];
+    basePath: string;
+    searchPath: string;
   };
 }
 
@@ -40,6 +40,7 @@ const fuseOptions = {
   ignoreLocation: true,
   minMatchCharLength: MIN_QUERY_LENGTH,
   threshold: 0.35,
+  includeMatches: true,
   keys: [
     { name: 'title', weight: 0.4 },
     { name: 'excerpt', weight: 0.25 },
@@ -54,25 +55,70 @@ function getInitialQuery(location: Location) {
   return new URLSearchParams(location.search).get('q') || '';
 }
 
+const highlightMatches = (text: string, matches: readonly Fuse.FuseResultMatch[] = [], key: string) => {
+  const match = matches.find((m) => m.key === key);
+  if (!match || !match.indices || match.indices.length === 0) return text;
+
+  let result: React.ReactNode[] = [];
+  let lastIndex = 0;
+
+  match.indices.forEach(([start, end], i) => {
+    if (start > lastIndex) {
+      result.push(text.slice(lastIndex, start));
+    }
+    result.push(
+      <mark key={`${key}-${i}`} style={{ backgroundColor: 'rgba(255, 225, 0, 0.4)', color: 'inherit', borderRadius: '2px', padding: '0 2px' }}>
+        {text.slice(start, end + 1)}
+      </mark>
+    );
+    lastIndex = end + 1;
+  });
+
+  if (lastIndex < text.length) {
+    result.push(text.slice(lastIndex));
+  }
+
+  return <>{result}</>;
+};
+
 const SearchPage: React.FC<SearchTemplateProps> = ({
   location,
-  pageContext,
 }) => {
-  const searchIndex = pageContext.searchIndex || [];
+  const [searchIndex, setSearchIndex] = useState<SearchItem[]>([]);
   const [query, setQuery] = useState(getInitialQuery(location));
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    fetch('/search-index.json')
+      .then((res) => res.json())
+      .then((data) => setSearchIndex(data))
+      .catch((err) => console.error('Failed to load search index', err));
+  }, []);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 200);
+    return () => clearTimeout(handler);
+  }, [query]);
 
   const fuse = useMemo(
     () => new Fuse<SearchItem>(searchIndex, fuseOptions),
     [searchIndex],
   );
 
-  const trimmedQuery = query.trim();
+  const trimmedQuery = debouncedQuery.trim();
   const hasSearchQuery = trimmedQuery.length >= MIN_QUERY_LENGTH;
   const hasQuery = query.length > 0;
 
   const results = useMemo(() => {
-    if (!hasSearchQuery) return searchIndex;
-    return fuse.search(trimmedQuery).map((result) => result.item);
+    if (!hasSearchQuery) return searchIndex as unknown as IArticle[];
+    return fuse.search(trimmedQuery).map((result) => {
+      const item = { ...result.item };
+      item.title = highlightMatches(item.title as string, result.matches, 'title');
+      item.excerpt = highlightMatches(item.excerpt as string, result.matches, 'excerpt');
+      return item;
+    }) as unknown as IArticle[];
   }, [fuse, hasSearchQuery, searchIndex, trimmedQuery]);
 
   return (
@@ -121,7 +167,7 @@ const SearchPage: React.FC<SearchTemplateProps> = ({
         </ResultsMeta>
 
         {results.length > 0 ? (
-          <ArticlesList articles={results as any} alwaysShowAllDetails />
+          <ArticlesList articles={results} alwaysShowAllDetails />
         ) : (
           <EmptyState>
             <EmptyTitle>No articles found</EmptyTitle>

--- a/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
+import { withPrefix } from 'gatsby';
 import Fuse from 'fuse.js';
 
 import Headings from '@components/Headings';
@@ -34,12 +35,14 @@ interface SearchTemplateProps {
 }
 
 const MIN_QUERY_LENGTH = 2;
+const MIN_MATCH_CHAR_LENGTH = 2;
+const FUSE_THRESHOLD = 0.28;
 
 const fuseOptions = {
   includeScore: true,
   ignoreLocation: true,
-  minMatchCharLength: MIN_QUERY_LENGTH,
-  threshold: 0.35,
+  minMatchCharLength: MIN_MATCH_CHAR_LENGTH,
+  threshold: FUSE_THRESHOLD,
   includeMatches: true,
   keys: [
     { name: 'title', weight: 0.4 },
@@ -55,21 +58,90 @@ function getInitialQuery(location: Location) {
   return new URLSearchParams(location.search).get('q') || '';
 }
 
-const highlightMatches = (text: string, matches: readonly Fuse.FuseResultMatch[] = [], key: string) => {
+function normalizeComparableText(value: string | React.ReactNode | string[]) {
+  if (Array.isArray(value)) return value.join(' ').toLowerCase();
+  if (typeof value === 'string') return value.toLowerCase();
+  return '';
+}
+
+function getRank(item: SearchItem, query: string) {
+  const normalizedQuery = query.toLowerCase();
+  const queryTokens = normalizedQuery
+    .split(/\s+/)
+    .filter((token) => token.length >= MIN_QUERY_LENGTH);
+  const title = normalizeComparableText(item.title);
+  const excerpt = normalizeComparableText(item.excerpt);
+  const author = normalizeComparableText(item.author);
+  const categories = normalizeComparableText(item.categories);
+  const body = normalizeComparableText(item.body);
+
+  const allTokensMatch = (value: string) =>
+    queryTokens.length > 0 &&
+    queryTokens.every((token) => value.includes(token));
+  const tokenHits = [title, excerpt, author, categories, body].reduce(
+    (count, value) =>
+      count + queryTokens.filter((token) => value.includes(token)).length,
+    0,
+  );
+
+  if (title === normalizedQuery) return { rank: 0, tokenHits };
+  if (title.startsWith(normalizedQuery)) return { rank: 1, tokenHits };
+  if (title.includes(normalizedQuery)) return { rank: 2, tokenHits };
+  if (
+    excerpt.includes(normalizedQuery) ||
+    categories.includes(normalizedQuery) ||
+    author.includes(normalizedQuery)
+  ) {
+    return { rank: 3, tokenHits };
+  }
+  if (allTokensMatch(title)) return { rank: 4, tokenHits };
+  if (
+    allTokensMatch(excerpt) ||
+    allTokensMatch(categories) ||
+    allTokensMatch(author)
+  ) {
+    return { rank: 5, tokenHits };
+  }
+  if (body.includes(normalizedQuery) || allTokensMatch(body)) {
+    return { rank: 6, tokenHits };
+  }
+
+  return { rank: 7, tokenHits };
+}
+
+const highlightMatches = (
+  text: string,
+  matches: readonly Fuse.FuseResultMatch[] = [],
+  key: string,
+) => {
   const match = matches.find((m) => m.key === key);
   if (!match || !match.indices || match.indices.length === 0) return text;
+
+  const sortedIndices = [...match.indices].sort((a, b) => a[0] - b[0]);
+  const mergedIndices: [number, number][] = [];
+
+  sortedIndices.forEach(([start, end]) => {
+    if (mergedIndices.length === 0) {
+      mergedIndices.push([start, end]);
+      return;
+    }
+    const last = mergedIndices[mergedIndices.length - 1];
+    if (start <= last[1] + 1) {
+      last[1] = Math.max(last[1], end);
+    } else {
+      mergedIndices.push([start, end]);
+    }
+  });
 
   let result: React.ReactNode[] = [];
   let lastIndex = 0;
 
-  match.indices.forEach(([start, end], i) => {
+  mergedIndices.forEach(([start, end], i) => {
     if (start > lastIndex) {
       result.push(text.slice(lastIndex, start));
     }
     result.push(
-      <mark key={`${key}-${i}`} style={{ backgroundColor: 'rgba(255, 225, 0, 0.4)', color: 'inherit', borderRadius: '2px', padding: '0 2px' }}>
-        {text.slice(start, end + 1)}
-      </mark>
+      <StyledMark key={`${key}-${i}`}>{text.slice(start, end + 1)}</StyledMark>,
     );
     lastIndex = end + 1;
   });
@@ -81,15 +153,13 @@ const highlightMatches = (text: string, matches: readonly Fuse.FuseResultMatch[]
   return <>{result}</>;
 };
 
-const SearchPage: React.FC<SearchTemplateProps> = ({
-  location,
-}) => {
+const SearchPage: React.FC<SearchTemplateProps> = ({ location }) => {
   const [searchIndex, setSearchIndex] = useState<SearchItem[]>([]);
   const [query, setQuery] = useState(getInitialQuery(location));
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
   useEffect(() => {
-    fetch('/search-index.json')
+    fetch(withPrefix('/search-index.json'))
       .then((res) => res.json())
       .then((data) => setSearchIndex(data))
       .catch((err) => console.error('Failed to load search index', err));
@@ -112,13 +182,37 @@ const SearchPage: React.FC<SearchTemplateProps> = ({
   const hasQuery = query.length > 0;
 
   const results = useMemo(() => {
-    if (!hasSearchQuery) return searchIndex as unknown as IArticle[];
-    return fuse.search(trimmedQuery).map((result) => {
-      const item = { ...result.item };
-      item.title = highlightMatches(item.title as string, result.matches, 'title');
-      item.excerpt = highlightMatches(item.excerpt as string, result.matches, 'excerpt');
-      return item;
-    }) as unknown as IArticle[];
+    if (!hasSearchQuery)
+      return searchIndex.slice(0, 10) as unknown as IArticle[];
+    return fuse
+      .search(trimmedQuery)
+      .map((result) => ({
+        ...result,
+        searchRank: getRank(result.item, trimmedQuery),
+      }))
+      .sort((a, b) => {
+        if (a.searchRank.rank !== b.searchRank.rank) {
+          return a.searchRank.rank - b.searchRank.rank;
+        }
+        if (a.searchRank.tokenHits !== b.searchRank.tokenHits) {
+          return b.searchRank.tokenHits - a.searchRank.tokenHits;
+        }
+        return (a.score || 0) - (b.score || 0);
+      })
+      .map((result) => {
+        const item = { ...result.item };
+        item.title = highlightMatches(
+          item.title as string,
+          result.matches,
+          'title',
+        );
+        item.excerpt = highlightMatches(
+          item.excerpt as string,
+          result.matches,
+          'excerpt',
+        );
+        return item;
+      }) as unknown as IArticle[];
   }, [fuse, hasSearchQuery, searchIndex, trimmedQuery]);
 
   return (
@@ -136,6 +230,7 @@ const SearchPage: React.FC<SearchTemplateProps> = ({
               aria-label="Search archive"
               autoComplete="off"
               autoFocus
+              data-search-input="true"
               name="q"
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search the archive"
@@ -171,7 +266,9 @@ const SearchPage: React.FC<SearchTemplateProps> = ({
         ) : (
           <EmptyState>
             <EmptyTitle>No articles found</EmptyTitle>
-            <EmptyText>{trimmedQuery}</EmptyText>
+            {trimmedQuery ? (
+              <EmptyText>No results for "{trimmedQuery}"</EmptyText>
+            ) : null}
           </EmptyState>
         )}
       </Section>
@@ -325,4 +422,11 @@ const EmptyText = styled.p`
   color: ${(p) => p.theme.colors.grey};
   font-size: 16px;
   line-height: 1.6;
+`;
+
+const StyledMark = styled.mark`
+  background-color: ${(p) => p.theme.colors.accent};
+  color: ${(p) => p.theme.colors.background};
+  border-radius: 2px;
+  padding: 0 2px;
 `;

--- a/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
+++ b/@pewriebontal/gatsby-theme-novela/src/templates/search.template.tsx
@@ -1,0 +1,282 @@
+import React, { useMemo, useState } from 'react';
+import styled from '@emotion/styled';
+import Fuse from 'fuse.js';
+
+import Headings from '@components/Headings';
+import Layout from '@components/Layout';
+import SEO from '@components/SEO';
+import Section from '@components/Section';
+import Icons from '@icons';
+import mediaqueries from '@styles/media';
+import ArticlesList from '../sections/articles/Articles.List';
+
+interface SearchItem {
+  author: string;
+  body: string;
+  categories: string[];
+  date: string;
+  excerpt: string;
+  hero?: {
+    narrow?: Record<string, unknown>;
+    regular?: Record<string, unknown>;
+  };
+  id: string;
+  slug: string;
+  timeToRead?: number;
+  title: string;
+}
+
+interface SearchTemplateProps {
+  location: Location;
+  pageContext: {
+    searchIndex: SearchItem[];
+  };
+}
+
+const MIN_QUERY_LENGTH = 2;
+
+const fuseOptions = {
+  includeScore: true,
+  ignoreLocation: true,
+  minMatchCharLength: MIN_QUERY_LENGTH,
+  threshold: 0.35,
+  keys: [
+    { name: 'title', weight: 0.4 },
+    { name: 'excerpt', weight: 0.25 },
+    { name: 'body', weight: 0.2 },
+    { name: 'author', weight: 0.1 },
+    { name: 'categories', weight: 0.05 },
+  ],
+};
+
+function getInitialQuery(location: Location) {
+  if (!location.search) return '';
+  return new URLSearchParams(location.search).get('q') || '';
+}
+
+const SearchPage: React.FC<SearchTemplateProps> = ({
+  location,
+  pageContext,
+}) => {
+  const searchIndex = pageContext.searchIndex || [];
+  const [query, setQuery] = useState(getInitialQuery(location));
+
+  const fuse = useMemo(
+    () => new Fuse<SearchItem>(searchIndex, fuseOptions),
+    [searchIndex],
+  );
+
+  const trimmedQuery = query.trim();
+  const hasSearchQuery = trimmedQuery.length >= MIN_QUERY_LENGTH;
+  const hasQuery = query.length > 0;
+
+  const results = useMemo(() => {
+    if (!hasSearchQuery) return searchIndex;
+    return fuse.search(trimmedQuery).map((result) => result.item);
+  }, [fuse, hasSearchQuery, searchIndex, trimmedQuery]);
+
+  return (
+    <Layout>
+      <SEO
+        pathname={location.pathname}
+        title="Search"
+        description="Search articles by title, author, category, excerpt, and body content."
+      />
+      <Section narrow>
+        <Hero>
+          <HiddenHeading>Search articles</HiddenHeading>
+          <SearchControl>
+            <SearchInput
+              aria-label="Search archive"
+              autoComplete="off"
+              autoFocus
+              name="q"
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search the archive"
+              type="text"
+              value={query}
+            />
+            {hasQuery ? (
+              <ClearButton
+                aria-label="Clear search"
+                onClick={() => setQuery('')}
+                type="button"
+              >
+                <Icons.Ex fill="currentColor" />
+              </ClearButton>
+            ) : (
+              <SearchIcon aria-hidden="true">
+                <Icons.Search fill="currentColor" />
+              </SearchIcon>
+            )}
+          </SearchControl>
+        </Hero>
+      </Section>
+
+      <Section narrow>
+        <ResultsMeta>
+          {hasSearchQuery
+            ? `${results.length} match${results.length === 1 ? '' : 'es'}`
+            : `${searchIndex.length} stories in the archive`}
+        </ResultsMeta>
+
+        {results.length > 0 ? (
+          <ArticlesList articles={results as any} alwaysShowAllDetails />
+        ) : (
+          <EmptyState>
+            <EmptyTitle>No articles found</EmptyTitle>
+            <EmptyText>{trimmedQuery}</EmptyText>
+          </EmptyState>
+        )}
+      </Section>
+    </Layout>
+  );
+};
+
+export default SearchPage;
+
+const Hero = styled.div`
+  position: relative;
+  z-index: 1;
+  margin: 120px auto 72px;
+
+  ${mediaqueries.desktop`
+    margin: 100px auto 64px;
+  `}
+
+  ${mediaqueries.phablet`
+    margin: 72px auto 44px;
+  `}
+`;
+
+const HiddenHeading = styled.h1`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
+const SearchControl = styled.div`
+  position: relative;
+  width: 100%;
+  color: ${(p) => p.theme.colors.primary};
+`;
+
+const SearchInput = styled.input`
+  display: block;
+  width: 100%;
+  height: 72px;
+  padding: 0 58px 0 0;
+  border: 0;
+  border-bottom: 2px solid ${(p) => p.theme.colors.horizontalRule};
+  border-radius: 0;
+  background: transparent;
+  color: ${(p) => p.theme.colors.primary};
+  font-size: 38px;
+  font-weight: 600;
+  line-height: 1.2;
+  transition: ${(p) => p.theme.colorModeTransition}, border-color 0.25s ease;
+
+  &::placeholder {
+    color: ${(p) => p.theme.colors.secondary};
+    opacity: 0.4;
+  }
+
+  &:focus {
+    border-color: ${(p) => p.theme.colors.accent};
+  }
+
+  ${mediaqueries.phablet`
+    height: 60px;
+    padding-right: 46px;
+    font-size: 27px;
+  `}
+`;
+
+const SearchIcon = styled.span`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  color: ${(p) => p.theme.colors.primary};
+  opacity: 0.28;
+  transform: translateY(-50%);
+`;
+
+const ClearButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  color: ${(p) => p.theme.colors.primary};
+  opacity: 0.35;
+  transform: translateY(-50%);
+  transition: opacity 0.25s ease;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+
+  &[data-a11y='true']:focus::after {
+    content: '';
+    position: absolute;
+    left: -10%;
+    top: -10%;
+    width: 120%;
+    height: 120%;
+    border: 2px solid ${(p) => p.theme.colors.accent};
+    background: rgba(255, 255, 255, 0.01);
+    border-radius: 50%;
+  }
+`;
+
+const ResultsMeta = styled.p`
+  position: relative;
+  z-index: 1;
+  margin: 0 0 42px;
+  color: ${(p) => p.theme.colors.grey};
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+
+  ${mediaqueries.phablet`
+    margin-bottom: 30px;
+    font-size: 13px;
+  `}
+`;
+
+const EmptyState = styled.div`
+  position: relative;
+  z-index: 1;
+  margin: 0 auto 120px;
+  max-width: 540px;
+  padding-top: 35px;
+  border-top: 1px solid ${(p) => p.theme.colors.horizontalRule};
+  text-align: center;
+`;
+
+const EmptyTitle = styled(Headings.h2)`
+  margin-bottom: 10px;
+`;
+
+const EmptyText = styled.p`
+  color: ${(p) => p.theme.colors.grey};
+  font-size: 16px;
+  line-height: 1.6;
+`;

--- a/@pewriebontal/gatsby-theme-novela/src/types/index.d.ts
+++ b/@pewriebontal/gatsby-theme-novela/src/types/index.d.ts
@@ -40,7 +40,9 @@ export interface IAuthor {
 export interface IArticle {
   slug: string;
   authors: IAuthor[];
-  excerpt: string;
+  title: string | React.ReactNode;
+  categories?: string[];
+  excerpt: string | React.ReactNode;
   body: string;
   id: string;
   hero: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@mdx-js/react": "^1.0.27",
         "@raae/gatsby-remark-oembed": "^0.1.1",
         "contentful-cli": "^1.16.0",
+        "fuse.js": "^6.6.2",
         "gatsby": "^3.15.0",
         "gatsby-image": "^2.2.7",
         "gatsby-paginate": "^1.1.0",
@@ -17351,6 +17352,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gatsby": {

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -63,6 +63,8 @@ const plugins = [
       basePath: "/",
       authorsPage: true,
       mailchimp: true,
+      search: true,
+      searchPath: "/search",
       sources: {
         local: true,
         contentful: false,


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [x] New feature (_adding a feature following a feature-request issue_)
* [x] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [x] (!) This change is or requires a documentation update

# Description

This PR introduces a client-side, fuzzy search functionality to the Novela theme, powered by `fuse.js`.

**Key Changes:**
1. **Search Index Generation (`createPages.js`)**: During the Gatsby build process, an index of all non-secret articles is generated (including title, excerpt, body, categories, and author). This index is saved as a static `public/search-index.json` file.
2. **Search Template (`search.template.tsx`)**: A new `/search` route is automatically created. It fetches the index asynchronously upon mounting and features a debounced search input (200ms) for performance on large blogs. Results are passed directly to the preexisting `ArticlesList` component.
3. **Keyword Highlighting**: Searched terms are accurately highlighted with `<mark>` tags in both the title and excerpts of the returned articles.
4. **Keyboard Shortcuts (`Navigation.Header.tsx`)**: 
   - Pressing `Cmd/Ctrl + K` from anywhere in the theme navigates to `/search` and auto-focuses the input.
   - Pressing `Cmd/Ctrl + K` while on the search page, or pressing `Escape`, immediately dismisses the search and navigates the user back to their previous page (or `/`).

## Additional information/context
This feature can be toggled or customized via the theme options in `gatsby-config.js` using `search: true` and specifying a `searchPath`.